### PR TITLE
fix: Workaround for Ingestion endpoint changes.

### DIFF
--- a/src/CluedIn.QualityAssurance.Cli/Operations/ClueSending/IngestionEndpoint/IngestionEndpointOperation.cs
+++ b/src/CluedIn.QualityAssurance.Cli/Operations/ClueSending/IngestionEndpoint/IngestionEndpointOperation.cs
@@ -230,7 +230,7 @@ internal class IngestionEndpointOperation : FileSourceOperationBase<IngestionEnd
         var body = await GetRequestTemplateAsync(nameof(CreateDataSetAsync)).ConfigureAwait(false);
         var replacedBody = body.Replace("{{UserId}}", Organization.UserId.ToString())
             .Replace("{{DataSourceId}}", FileSource.DataSourceId.ToString())
-            .Replace("{{EntityType}}", FileSource.EntityType);
+            .Replace("{{EntityType}}", FileSource.EntityType + "Dummy");
 
         var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
         {


### PR DESCRIPTION
Create a dummy entitytype when creating dataset to prevent issues when creating annotation later on.